### PR TITLE
[FEAT] 엔티티 연관관계에 지연로딩 추가 및 동네 생활 "취미생활" 카테고리 추가 반영

### DIFF
--- a/CarrotServer/src/main/java/CarrotServer/domain/Albums.java
+++ b/CarrotServer/src/main/java/CarrotServer/domain/Albums.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 public class Albums {
     @Id @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
     private Long albumId;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "clubId")
     private Clubs club;
     private String albumImg;

--- a/CarrotServer/src/main/java/CarrotServer/domain/LifeCategory.java
+++ b/CarrotServer/src/main/java/CarrotServer/domain/LifeCategory.java
@@ -8,7 +8,8 @@ public enum LifeCategory {
     DICTIONARY("동네백과"),
     QUESTION("동네질문"),
     ACCIDENT("동네사건사고"),
-    INFORMATION("생활정보");
+    INFORMATION("생활정보"),
+    HOBBY("취미생활");
 
     private final String name;
 }

--- a/CarrotServer/src/main/java/CarrotServer/domain/Profiles.java
+++ b/CarrotServer/src/main/java/CarrotServer/domain/Profiles.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 public class Profiles {
     @Id @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
     private Long profileId;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="clubId")
     private Clubs club;
     private String nickname;


### PR DESCRIPTION
## 🥕 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🥕 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#8 -> dev
- closed #8 

## 🥕 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 엔티티 연관관계에 지연로딩 속성을 추가했습니다
- 피그마 확인 결과 동네 생활에서 취미생활 카테고리가 추가되어 반영했습니다

## 🥕 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 🥕 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
